### PR TITLE
add Makerlog (getMakerlog.com) as site

### DIFF
--- a/src/main/resources/static/sites.json
+++ b/src/main/resources/static/sites.json
@@ -473,5 +473,10 @@
     "service": "Mastodon",
     "url": "https://mstdn.io/@{}",
     "urlMain": "https://mstdn.io/"
+  },
+  {
+    "service": "Makerlog",
+    "url": "https://getmakerlog.com/@{}",
+    "urlMain": "https://getmakerlog.com/"
   }
 ]


### PR DESCRIPTION
Would be cool to have [Makerlog](https://getMakerlog.com) added as a site.